### PR TITLE
Support ActiveModel 4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .bundle
 .config
 .yardoc
-Gemfile.lock
+Gemfile*.lock
 InstalledFiles
 _yardoc
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,9 @@ rvm:
 - 2.0.0
 - 2.1.3
 
+gemfile:
+- Gemfile.activerecord40
+- Gemfile.activerecord41
+
 before_script:
 - mysql -e 'create database database_validations;'

--- a/Gemfile.activerecord40
+++ b/Gemfile.activerecord40
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gemspec
+
+gem 'activerecord', '~> 4.0.0'

--- a/Gemfile.activerecord41
+++ b/Gemfile.activerecord41
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gemspec
+
+gem 'activerecord', '~> 4.1.0'

--- a/activerecord-databasevalidations.gemspec
+++ b/activerecord-databasevalidations.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activerecord", "~> 4"
+  spec.add_runtime_dependency "activerecord", "~> 4.0"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "minitest", "~> 5"
+  spec.add_development_dependency "minitest"
   spec.add_development_dependency "mysql2"
 end

--- a/test/database_constraints_validator_test.rb
+++ b/test/database_constraints_validator_test.rb
@@ -49,14 +49,14 @@ class DatabaseConstraintsValidatorTest < Minitest::Test
 
   def test_not_null_field_defines_not_null_validator_if_requested
     validator = Foo._validators[:checked].first
-    subvalidators = validator.attribute_validators(:checked)
+    subvalidators = validator.attribute_validators(Foo, :checked)
     assert_equal 1, subvalidators.length
     assert_kind_of ActiveModel::Validations::NotNullValidator, subvalidators.first
   end
 
   def test_string_field_defines_length_validator_by_default
     validator = Foo._validators[:string].first
-    subvalidators = validator.attribute_validators(:string)
+    subvalidators = validator.attribute_validators(Foo, :string)
     assert_equal 1, subvalidators.length
     assert_kind_of ActiveModel::Validations::LengthValidator, subvalidators.first
     assert_equal 40, subvalidators.first.options[:maximum]
@@ -64,7 +64,7 @@ class DatabaseConstraintsValidatorTest < Minitest::Test
 
   def test_blob_field_defines_bytesize_validator
     validator = Foo._validators[:blob].first
-    subvalidators = validator.attribute_validators(:blob)
+    subvalidators = validator.attribute_validators(Foo, :blob)
     assert_equal 1, subvalidators.length
     assert_kind_of ActiveModel::Validations::BytesizeValidator, subvalidators.first
     assert_equal 65535, subvalidators.first.options[:maximum]
@@ -73,7 +73,7 @@ class DatabaseConstraintsValidatorTest < Minitest::Test
 
   def test_not_null_text_field_defines_requested_bytesize_validator_and_unicode_validator
     validator = Foo._validators[:not_null_text].first
-    subvalidators = validator.attribute_validators(:not_null_text)
+    subvalidators = validator.attribute_validators(Foo, :not_null_text)
     assert_equal 2, subvalidators.length
 
     assert_kind_of ActiveModel::Validations::BytesizeValidator, subvalidators.first
@@ -90,7 +90,7 @@ class DatabaseConstraintsValidatorTest < Minitest::Test
 
   def test_should_not_create_a_validor_for_a_utf8mb4_field
     assert Bar.new(mb4_string: '💩').valid?
-    Bar._validators[:mb4_string].first.attribute_validators(:mb4_string).empty?
+    Bar._validators[:mb4_string].first.attribute_validators(Bar, :mb4_string).empty?
   end
 
   def test_error_messages

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,8 @@ require "yaml"
 
 require "active_record/database_validations"
 
+Minitest::Test = MiniTest::Unit::TestCase unless defined?(MiniTest::Test)
+
 database_yml = YAML.load_file(File.expand_path('../database.yml', __FILE__))
 ActiveRecord::Base.establish_connection(database_yml['test'])
 I18n.enforce_available_locales = false


### PR DESCRIPTION
ActiveModel 4.0.x unfortunately does not send :class as an option to the validator’s constructor.
