### PR TITLE
close code block in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can also use `validates_database_constraints_of`:
 class Bar < ActiveRecord::Base
   validates_database_constraints_of :my_field, with: :size
 end
+```
 
 ### Available validations
 


### PR DESCRIPTION
adds missing closing backticks in README.md
