### PR TITLE
Generate a named method to truncate instead of a anonymous lambda

### DIFF
--- a/lib/active_record/validations/string_truncator.rb
+++ b/lib/active_record/validations/string_truncator.rb
@@ -5,35 +5,32 @@ module ActiveRecord
 
       module ClassMethods
         def truncate_string(field)
-          column = self.columns_hash[field.to_s]
-          case column.type
-          when :string
-            lambda do
-              return unless self.changes.key?(field.to_s)
-              return if self[field].nil?
+          method_name = :"truncate_#{field}_at_database_limit"
+          define_method(method_name) do
+            return unless self.changes.key?(field.to_s)
+            return if self[field].nil?
 
-              limit = StringTruncator.mysql_textual_column_limit(column)
+            column = self.class.columns_hash[field.to_s]
+            limit = StringTruncator.mysql_textual_column_limit(column)
+
+            case column.type
+            when :string
               value = self[field].to_s
               if limit && value.length > limit
                 self[field] = value.slice(0, limit)
               end
-              return true # to make sure the callback chain doesn't halt
-            end
 
-          when :text
-            lambda do
-              return unless self.changes.key?(field.to_s)
-              return if self[field].nil?
-
-              limit = StringTruncator.mysql_textual_column_limit(column)
+            when :text
               value = self[field].to_s
               value.encode!('utf-8') if value.encoding != Encoding::UTF_8
               if limit && value.bytesize > limit
                 self[field] = value.mb_chars.limit(limit).to_s
               end
-              return true # to make sure the callback chain doesn't halt
             end
+
+            return # to make sure the callback chain doesn't halt
           end
+          return method_name
         end
       end
 


### PR DESCRIPTION
This will generate a named method to truncate the field, instead of using an anonymous proc. See #7 for the original implementation.

@christianblais
