### PR TITLE
Fix tests compatibility with ActiveRecord 4.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
 gemfile:
 - Gemfile.activerecord40
 - Gemfile.activerecord41
+- Gemfile.activerecord42
 
 before_script:
 - mysql -e 'create database database_validations;'

--- a/Gemfile.activerecord42
+++ b/Gemfile.activerecord42
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gemspec
+
+gem 'activerecord', '~> 4.2.0'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,8 @@ module DataLossAssertions
 
     persisted_values = record.reload.attributes.slice(*attributes)
     refute_equal provided_values, persisted_values
+  rescue RangeError
+    pass
   end
 
   def refute_data_loss(record)


### PR DESCRIPTION
Tests were not passing with the latest version of ActiveRecord. Rescue RangeError's that are now thrown by ActiveRecord for integer values that fall out of the limit's range.

@wvanbergen 