### PR TITLE
Fix exception message when column isn't found

### DIFF
--- a/lib/active_record/validations/database_constraints.rb
+++ b/lib/active_record/validations/database_constraints.rb
@@ -63,8 +63,13 @@ module ActiveRecord
 
       def attribute_validators(klass, attribute)
         @constraint_validators[attribute] ||= begin
-          column = klass.columns_hash[attribute.to_s] or raise ArgumentError.new("Model #{self.class.name} does not have column #{column_name}!")
-          column = ActiveRecord::Validations::TypedColumn.new(column)
+          column_definition = klass.columns_hash[attribute.to_s]
+
+          unless column_definition
+            raise ArgumentError.new("Model #{klass.name} does not have column #{attribute.to_s}!")
+          end
+
+          column = ActiveRecord::Validations::TypedColumn.new(column_definition)
 
           [
             not_null_validator(klass, column),

--- a/test/database_constraints_validator_test.rb
+++ b/test/database_constraints_validator_test.rb
@@ -17,6 +17,8 @@ ActiveRecord::Migration.suppress_messages do
     t.string   :mb4_string
   end
 
+  ActiveRecord::Migration.create_table("empties", force: true)
+
   ActiveRecord::Migration.create_table("nums", force: true) do |t|
     t.column :decimal,          "DECIMAL(5,2)"
     t.column :unsigned_decimal, "DECIMAL(5,2) UNSIGNED"
@@ -39,6 +41,12 @@ class Bar < ActiveRecord::Base
   validates :mb4_string, database_constraints: :basic_multilingual_plane
 end
 
+class Empty < ActiveRecord::Base
+  attr_accessor :not_a_column
+
+  validates(:not_a_column, database_constraints: [:size])
+end
+
 class Num < ActiveRecord::Base
   validates :decimal, :unsigned_decimal, :tinyint, :smallint, :mediumint, :int, :bigint, :unsigned_int, database_constraints: :range
 end
@@ -51,6 +59,11 @@ class DatabaseConstraintsValidatorTest < Minitest::Test
     assert_raises(ArgumentError) { Bar.validates(:mb4_string, database_constraints: true) }
     assert_raises(ArgumentError) { Bar.validates(:mb4_string, database_constraints: :bogus) }
     assert_raises(ArgumentError) { Bar.validates(:mb4_string, database_constraints: [:size, :bogus]) }
+  end
+
+  def test_column_validation
+    exception = assert_raises(ArgumentError) { Empty.new.valid? }
+    assert_equal "Model Empty does not have column not_a_column!", exception.message
   end
 
   def test_validators_are_defined


### PR DESCRIPTION
When `klass.columns_hash[attribute.to_s]` returns `nil` the following error occurs:

```
    NameError: undefined local variable or method `column_name' for #<ActiveRecord::Validations::DatabaseConstraintsValidator:0x007fe6bd6d5960>
Did you mean?  column
    ~/.gem/ruby/2.3.3/gems/activerecord-databasevalidations-0.3.0/lib/active_record/validations/database_constraints.rb:66 in `attribute_validators`
    ~/.gem/ruby/2.3.3/gems/activerecord-databasevalidations-0.3.0/lib/active_record/validations/database_constraints.rb:79 in `validate_each`
    ~/.gem/ruby/2.3.3/bundler/gems/rails-e29d9ce205e3/activemodel/lib/active_model/validator.rb:151 in `block in validate`
    ~/.gem/ruby/2.3.3/bundler/gems/rails-e29d9ce205e3/activemodel/lib/active_model/validator.rb:148 in `each`
    ~/.gem/ruby/2.3.3/bundler/gems/rails-e29d9ce205e3/activemodel/lib/active_model/validator.rb:148 in `validate`
```