### PR TITLE
Use activerecord 5.0.0 from RubyGems

### DIFF
--- a/Gemfile.activerecord50
+++ b/Gemfile.activerecord50
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'activerecord', github: 'rails/rails'
+gem 'activerecord', '~> 5.0.0'


### PR DESCRIPTION
Attempts to fix CI

Example failed build: https://travis-ci.org/wvanbergen/activerecord-databasevalidations/jobs/282792739