### PR TITLE
Stop mutating the string returned by Symbol#to_s

### DIFF
--- a/lib/active_record/database_validations/mysql.rb
+++ b/lib/active_record/database_validations/mysql.rb
@@ -64,8 +64,12 @@ module ActiveRecord
 
       def self.value_for_column(value, column_encoding = nil)
         value = value.to_s unless value.is_a?(String)
-        value.encode!('utf-8') if requires_transcoding?(value, column_encoding)
-        return value
+
+        if requires_transcoding?(value, column_encoding)
+          return value.encode(Encoding::UTF_8)
+        end
+
+        value
       end
     end
   end


### PR DESCRIPTION
MRI is currently experimenting with returning a frozen string in `Symbol#to_s`, see https://github.com/ruby/ruby/pull/2437

Unless that experimental feature end up reverted, this gem need to be updated.

@wvanbergen @rafaelfranca 