### PR TITLE
Various CI fixes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: ruby
 cache: bundler
+services:
+  - mysql
 
 rvm:
 - 2.2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,23 +5,12 @@ services:
   - mysql
 
 rvm:
-- 2.2.2
-- 2.3.0
-- 2.4.1
-- 2.5.0
+- '2.5'
+- '2.6'
 
 gemfile:
-  - gemfiles/Gemfile.activerecord50
-  - gemfiles/Gemfile.activerecord51
   - gemfiles/Gemfile.activerecord52
-  - gemfiles/Gemfile.activerecord-edge
-
-matrix:
-  exclude:
-    - rvm: 2.2.2
-      gemfile: gemfiles/Gemfile.activerecord-edge
-    - rvm: 2.3.0
-      gemfile: gemfiles/Gemfile.activerecord-edge
+  - gemfiles/Gemfile.activerecord60
 
 before_script:
 - mysql -e 'create database database_validations;'

--- a/activerecord-databasevalidations.gemspec
+++ b/activerecord-databasevalidations.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.2.2'
+  spec.required_ruby_version = '>= 2.5'
 
-  spec.add_runtime_dependency "activerecord", ">= 5.0"
+  spec.add_runtime_dependency "activerecord", ">= 5.2"
   spec.add_runtime_dependency "rejectu"
 
   spec.add_development_dependency "bundler", "~> 1.5"

--- a/gemfiles/Gemfile.activerecord-edge
+++ b/gemfiles/Gemfile.activerecord-edge
@@ -1,4 +1,0 @@
-source 'https://rubygems.org'
-gemspec path: '..'
-
-gem 'activerecord', github: 'rails/rails', branch: 'master'

--- a/gemfiles/Gemfile.activerecord50
+++ b/gemfiles/Gemfile.activerecord50
@@ -1,4 +1,0 @@
-source 'https://rubygems.org'
-gemspec path: '..'
-
-gem 'activerecord', '~> 5.0.0'

--- a/gemfiles/Gemfile.activerecord52
+++ b/gemfiles/Gemfile.activerecord52
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gemspec path: '..'
 
-gem 'activerecord', github: 'rails/rails', branch: '5-2-stable'
+gem 'activerecord', '~> 5.2.0'

--- a/gemfiles/Gemfile.activerecord60
+++ b/gemfiles/Gemfile.activerecord60
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gemspec path: '..'
 
-gem 'activerecord', '~> 5.1.0'
+gem 'activerecord', '~> 6.0.0'

--- a/test/data_loss_test.rb
+++ b/test/data_loss_test.rb
@@ -33,8 +33,8 @@ class DataLossTest < Minitest::Test
   end
 
   def test_decimal_silently_changes_out_of_bound_values
-    maximum = BigDecimal.new(10 **  (Unicorn.columns_hash['decimal'].precision - Unicorn.columns_hash['decimal'].scale))
-    delta   = BigDecimal.new(10 ** -(Unicorn.columns_hash['decimal'].scale), Unicorn.columns_hash['decimal'].precision)
+    maximum = BigDecimal(10 **  (Unicorn.columns_hash['decimal'].precision - Unicorn.columns_hash['decimal'].scale))
+    delta   = BigDecimal(10 ** -(Unicorn.columns_hash['decimal'].scale), Unicorn.columns_hash['decimal'].precision)
 
     refute_data_loss Unicorn.new(decimal: maximum - delta)
     assert_data_loss Unicorn.new(decimal: maximum)
@@ -42,8 +42,8 @@ class DataLossTest < Minitest::Test
     assert_data_loss Unicorn.new(decimal: 0 - maximum)
 
 
-    maximum = BigDecimal.new(10 **  (Unicorn.columns_hash['unsigned_decimal'].precision - Unicorn.columns_hash['unsigned_decimal'].scale))
-    delta   = BigDecimal.new(10 ** -(Unicorn.columns_hash['unsigned_decimal'].scale), Unicorn.columns_hash['unsigned_decimal'].precision)
+    maximum = BigDecimal(10 **  (Unicorn.columns_hash['unsigned_decimal'].precision - Unicorn.columns_hash['unsigned_decimal'].scale))
+    delta   = BigDecimal(10 ** -(Unicorn.columns_hash['unsigned_decimal'].scale), Unicorn.columns_hash['unsigned_decimal'].precision)
 
     refute_data_loss Unicorn.new(unsigned_decimal: maximum - delta)
     assert_data_loss Unicorn.new(unsigned_decimal: maximum)
@@ -99,7 +99,7 @@ class DataLossTest < Minitest::Test
   end
 
   def test_utf8mb3_field_sliently_truncates_strings_after_first_4byte_character
-    emoji = '💩'
+    emoji = "\u{1F4A9}"
     assert_equal 1, emoji.length
     assert_equal 4, emoji.bytesize
     assert_data_loss Unicorn.new(string: emoji)

--- a/test/database_constraints_validator_test.rb
+++ b/test/database_constraints_validator_test.rb
@@ -98,7 +98,7 @@ class DatabaseConstraintsValidatorTest < Minitest::Test
     assert_equal 1, subvalidators.length
     assert_kind_of ActiveModel::Validations::BytesizeValidator, subvalidators.first
     assert_equal 65535, subvalidators.first.options[:maximum]
-    assert_equal nil, subvalidators.first.encoding
+    assert_nil subvalidators.first.encoding
   end
 
   def test_not_null_text_field_defines_requested_bytesize_validator_and_unicode_validator
@@ -120,7 +120,7 @@ class DatabaseConstraintsValidatorTest < Minitest::Test
 
   def test_should_not_create_a_validator_for_a_utf8mb4_field
     assert Bar._validators[:mb4_string].first.attribute_validators(Bar, :mb4_string).empty?
-    emoji = Bar.new(mb4_string: '💩')
+    emoji = Bar.new(mb4_string: '')
     assert emoji.valid?
     refute_data_loss emoji
   end
@@ -214,7 +214,7 @@ class DatabaseConstraintsValidatorTest < Minitest::Test
   end
 
   def test_error_messages
-    foo = Foo.new(string: 'ü' * 41, checked: nil, not_null_text: '💩')
+    foo = Foo.new(string: 'ü' * 41, checked: nil, not_null_text: '')
     refute foo.save
 
     assert_equal ["is too long (maximum is 40 characters)"], foo.errors[:string]

--- a/test/database_constraints_validator_test.rb
+++ b/test/database_constraints_validator_test.rb
@@ -214,7 +214,7 @@ class DatabaseConstraintsValidatorTest < Minitest::Test
   end
 
   def test_error_messages
-    foo = Foo.new(string: 'ü' * 41, checked: nil, not_null_text: '')
+    foo = Foo.new(string: 'ü' * 41, checked: nil, not_null_text: "\u{1F4A9}")
     refute foo.save
 
     assert_equal ["is too long (maximum is 40 characters)"], foo.errors[:string]

--- a/test/varchar_default_size_test.rb
+++ b/test/varchar_default_size_test.rb
@@ -14,7 +14,7 @@ class VarcharDefaultSizeTest < Minitest::Test
       ActiveRecord::Migration.add_index(:varchars, :string, unique: true)
     end
 
-    assert_match /\Autf8mb4_/, Varchar.columns_hash['string'].collation
-    assert_equal 191, Varchar.columns_hash['string'].limit
+    assert_match(/\Autf8mb4_/, Varchar.columns_hash['string'].collation)
+    assert_equal(191, Varchar.columns_hash['string'].limit)
   end
 end


### PR DESCRIPTION
Lots of different things here, non exhaustive list:

  - Updated rvm list to test only ruby 2.5 and 2.6
  - Updated gemfile list to test only rails 5.2 and 6.0
  - Fixed various minitest and ruby warnings
  - Updated the gemspec to require Rails 5.2+ and MRI 2.5+